### PR TITLE
Improve comment container layout with overflow handling

### DIFF
--- a/apps/web/src/components/comment/comment-code-block.tsx
+++ b/apps/web/src/components/comment/comment-code-block.tsx
@@ -56,7 +56,13 @@ const CommentCodeBlock = (props: CommentCodeBlockProps) => {
   const codeHtml = /<code\b[^>]*>([\s\S]*?)<\/code>/.exec(highlightedHtml)?.[1]
 
   return (
-    <CodeBlock data-lang={lang} title={title} className='shiki' figureClassName='my-2'>
+    <CodeBlock
+      data-lang={lang}
+      title={title}
+      className='shiki'
+      figureClassName='my-2'
+      scrollAreaClassName='h-120'
+    >
       {isHighlighted && codeHtml ? (
         <code
           dangerouslySetInnerHTML={{

--- a/apps/web/src/components/comment/comment.tsx
+++ b/apps/web/src/components/comment/comment.tsx
@@ -85,7 +85,7 @@ const Comment = (props: CommentProps) => {
             height={32}
             className='z-10 size-8 rounded-full'
           />
-          <div className='flex-1'>
+          <div className='flex-1 overflow-hidden'>
             <div className='ml-0.5 flex h-8 items-center justify-between'>
               <div className='flex items-center gap-2 text-sm'>
                 <div className='font-semibold'>{name}</div>


### PR DESCRIPTION
## What's changed

- Add `overflow-hidden` to the comment container to enhance layout management and prevent overflow issues.

- Set height to comment code block scroll area to have better layout