### PR TITLE
Fix relative date diff bug

### DIFF
--- a/apps/web/src/hooks/use-formatted-date.ts
+++ b/apps/web/src/hooks/use-formatted-date.ts
@@ -22,7 +22,7 @@ export const useFormattedDate = (date: Date | string, options: Options = {}) => 
   const convertedDate = typeof date === 'string' ? new Date(date) : date
 
   if (relative) {
-    const weeksDiff = dayjs().diff(date, 'week')
+    const weeksDiff = dayjs().diff(convertedDate, 'week')
 
     return Math.abs(weeksDiff) > 1
       ? format.dateTime(convertedDate, formatOptions)


### PR DESCRIPTION
## Summary
- fix useFormattedDate to use parsed date when computing the relative time diff

## Testing
- `pnpm test:unit` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6852557b534c832c9d7c73929c356483